### PR TITLE
Wait for external data to be loaded

### DIFF
--- a/inline_svg.js
+++ b/inline_svg.js
@@ -1,25 +1,28 @@
 Reveal.getSlides().forEach(function(s){
-  s.querySelectorAll("object").forEach(function(e) {
-    var params;
-    params = e.querySelectorAll("param");
-    //replacing object with inline svg
-    if (e.contentDocument)
-       e.parentElement.replaceChild(e.contentDocument.documentElement.cloneNode(true), e);
-    //Setting "preserveAspectRatio" for each SVG to scale correctly
-    s.querySelectorAll("svg").forEach(function(e){
-      e.setAttribute("preserveAspectRatio","xMinYMin meet");
+  // Hope external data has been loaded after timeout
+  window.setTimeout(function() {
+    s.querySelectorAll("object").forEach(function(e) {
+      var params;
+      params = e.querySelectorAll("param");
+      //replacing object with inline svg
+      if (e.contentDocument)
+        e.parentElement.replaceChild(e.contentDocument.documentElement.cloneNode(true), e);
+      //Setting "preserveAspectRatio" for each SVG to scale correctly
+      s.querySelectorAll("svg").forEach(function(e){
+        e.setAttribute("preserveAspectRatio","xMinYMin meet");
+      });
+      //applying formating according to params
+      params.forEach(function(p){
+        var svg_e;
+        //get svg element with the same id
+        svg_e = s.querySelector("#".concat(p.getAttribute("id")));
+        //apply the attributes of the param element to the svg element
+        var attrs = p.attributes;
+        for(var i = attrs.length - 1; i >= 0; i--) {
+          if (attrs[i].name!="id")
+          svg_e.setAttribute(attrs[i].name, attrs[i].value);
+        }
+      });
     });
-    //applying formating according to params
-    params.forEach(function(p){
-      var svg_e;
-      //get svg element with the same id
-      svg_e = s.querySelector("#".concat(p.getAttribute("id")));
-      //apply the attributes of the param element to the svg element
-      var attrs = p.attributes;
-      for(var i = attrs.length - 1; i >= 0; i--) {
-        if (attrs[i].name!="id")
-         svg_e.setAttribute(attrs[i].name, attrs[i].value);
-       }
-    });
-  });
+  }), 1000
 });


### PR DESCRIPTION
Adds an one second timeout that seems to be sufficient for the browser to load the object data. I've had some null reference errors before. Those are gone now.

May fix #1. At least it works reliably for me under Brave (which is based on Chrome).